### PR TITLE
建议：设置 ValidationExceptions code 的值为 400

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -30,7 +30,7 @@ if (!function_exists('validator')) {
             foreach ($validator->messages() as $fieldMessages) {
                 $messages .= implode(';', $fieldMessages) . ';';
             }
-            throw new ValidationExceptions($messages);
+            throw new ValidationExceptions($messages, 400);
         }
         return $validator;
     }


### PR DESCRIPTION
如果在 fastD 使用，没有设置 code 的值，默认是 502。这并不科学啊。

建议这里把 code 设置成 400（Bad Request）。

fastD 异常处理逻辑：
```php
<?php
class Application
{
    /**
     * @param Exception $e
     *
     * @return Response
     */
    public function renderException(Exception $e)
    {
        $statusCode = ($e instanceof HttpException) ? $e->getStatusCode() : $e->getCode();

        if (!array_key_exists($statusCode, Response::$statusTexts)) {
            $statusCode = 502;
        }

        return json(call_user_func(config()->get('exception.response'), $e), $statusCode);
    }
}
```